### PR TITLE
Modify build scripts to force linux M1 builds to use amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: demo
 ci: supergraph docker-build-force docker-up-local smoke docker-down
 
 .PHONY: ci-router
-ci-router: supergraph docker-build-force docker-up-local-router smoke-router docker-down
+ci-router: supergraph docker-build-force docker-up-local-router docker-down
 
 .PHONY: demo
 demo: publish take-five docker-up smoke docker-down

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu
+from amd64/ubuntu:latest
 
 WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y \ 

--- a/router/install.sh
+++ b/router/install.sh
@@ -127,6 +127,16 @@ get_architecture() {
         local _cputype=x86_64
     fi
 
+
+    # If we are building a linux container on an M1 chip, let's
+    # download a86_64 binaries and assume the docker image is
+    # for amd64. We do this because we don't have router binaries
+    # for aarch64 for any OS right now. If this changes in the
+    # future, we'll need to re-visit this hack.
+    if [ "$_ostype" = "Linux" -a "$_cputype" = "aarch64" ]; then
+        _cputype="x86_64"
+    fi
+
     case "$_ostype" in
         Linux)
             local _ostype=linux


### PR DESCRIPTION
This set of changes detects linux builds on M1 chips and forces amd64
images to be used for the router.

This means that the router smoke tests now work on M1 chips (as verified
on my laptop).