### PR TITLE
Docker shutdown signal support

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-from amd64/ubuntu:latest
+FROM amd64/ubuntu:latest
 
 WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y \ 
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y \
     jq
 
 COPY install.sh .
-COPY run.sh .
 RUN ./install.sh
 
-CMD [ "/usr/src/app/run.sh" ]
+CMD [ "/usr/src/app/router", "-c", "/etc/config/configuration.yaml", "-s", "/etc/config/supergraph.graphql", "--log", "info" ]

--- a/router/run.sh
+++ b/router/run.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-./router --version
-./router -c /etc/config/configuration.yaml -s /etc/config/supergraph.graphql --log info


### PR DESCRIPTION
fixes https://github.com/apollographql/router/issues/320

It turns out docker signals weren't propagated from the shell script to the binary, which caused the apollo-router container to wait until it received a SIGKILL (after 10s)

This pr removes the shell entrypoint, which get's the docker-compose shutdown time back to an acceptable delay (1.8 seconds on my machine)