### PR TITLE
inconsistent directive definitions across subgraphs

### DIFF
--- a/subgraphs/pandas/pandas.graphql
+++ b/subgraphs/pandas/pandas.graphql
@@ -1,3 +1,5 @@
+directive @tag(name: String!) repeatable on FIELD_DEFINITION
+
 type Query {
   allPandas: [Panda]
   panda(name: ID!): Panda
@@ -5,5 +7,5 @@ type Query {
 
 type Panda {
     name:ID!
-    favoriteFood: String
+    favoriteFood: String @tag(name: "nom nom nom")
 }

--- a/subgraphs/products/products.graphql
+++ b/subgraphs/products/products.graphql
@@ -1,3 +1,5 @@
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT
+
 extend schema
     @link(url: "https://specs.apollo.dev/federation/v2.0",
        import: ["@key", "@shareable", "@tag"])

--- a/subgraphs/products/products.graphql
+++ b/subgraphs/products/products.graphql
@@ -1,6 +1,6 @@
 extend schema
     @link(url: "https://specs.apollo.dev/federation/v2.0",
-       import: ["@key", "@shareable"])
+       import: ["@key", "@shareable", "@tag"])
 
 type Query {
   allProducts: [ProductItf]
@@ -21,7 +21,7 @@ interface SkuItf {
 }
 
 type Product implements ProductItf & SkuItf @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }"){
-  id: ID!
+  id: ID! @tag(name: "hi-from-products")
   sku: String
   package: String
   variation: ProductVariation

--- a/subgraphs/users/users.graphql
+++ b/subgraphs/users/users.graphql
@@ -1,5 +1,7 @@
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT
+
 type User @key(fields:"email") {
-    email:ID!
+    email:ID! @tag(name: "test from users")
     name: String
     totalProductsCreated: Int
 }

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -2,6 +2,7 @@
 schema
   @core(feature: "https://specs.apollo.dev/core/v0.2")
   @core(feature: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+  @core(feature: "https://specs.apollo.dev/tag/v0.1")
 {
   query: Query
 }
@@ -15,6 +16,8 @@ directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
 directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
 enum core__Purpose {
   """


### PR DESCRIPTION
```
+ rover fed2 supergraph compose --config ./supergraph.yaml
WARN: [InconsistentInterfaceValueTypeField]: Field "ProductItf.delivery" of interface type "ProductItf" is not defined in all the subgraphs defining "ProductItf" (but can always be resolved from these subgraphs): "ProductItf.delivery" is defined in subgraph "inventory" but not in subgraph "products".
WARN: [InconsistentInterfaceValueTypeField]: Field "ProductItf.sku" of interface type "ProductItf" is not defined in all the subgraphs defining "ProductItf" (but can always be resolved from these subgraphs): "ProductItf.sku" is defined in subgraph "products" but not in subgraph "inventory".
WARN: [InconsistentInterfaceValueTypeField]: Field "ProductItf.package" of interface type "ProductItf" is not defined in all the subgraphs defining "ProductItf" (but can always be resolved from these subgraphs): "ProductItf.package" is defined in subgraph "products" but not in subgraph "inventory".
WARN: [InconsistentInterfaceValueTypeField]: Field "ProductItf.variation" of interface type "ProductItf" is not defined in all the subgraphs defining "ProductItf" (but can always be resolved from these subgraphs): "ProductItf.variation" is defined in subgraph "products" but not in subgraph "inventory".
WARN: [InconsistentInterfaceValueTypeField]: Field "ProductItf.createdBy" of interface type "ProductItf" is not defined in all the subgraphs defining "ProductItf" (but can always be resolved from these subgraphs): "ProductItf.createdBy" is defined in subgraph "products" but not in subgraph "inventory".
WARN: [InconsistentEnumValue]: Value "OVERNIGHT" of enum type "ShippingClass" is only defined in a subset of the subgraphs defining "ShippingClass" (but can always be resolved from these subgraphs): "OVERNIGHT" is defined in subgraph "inventory" but not in subgraph "products".
WARN: [InconsistentTypeSystemDirectiveRepeatable]: Type system directive "@tag" is marked repeatable in the supergraph but it is inconsistently marked repeatable in subgraphs: it is repeatable in subgraphs "inventory", "pandas" and "users" but not in subgraph "products".
WARN: [InconsistentTypeSystemDirectiveLocations]: Type system directive "@tag" has inconsistent locations accross subgraphs and will use locations "FIELD_DEFINITION, INTERFACE, OBJECT, UNION" (union of all subgraphs) in the supergraph, but has: locations "FIELD_DEFINITION, INTERFACE, OBJECT, UNION" in subgraphs "inventory", "pandas" and "users" and location "FIELD_DEFINITION" in subgraph "products".
```
Signed-off-by: Phil Prasek <prasek@gmail.com>