### PR TITLE
speed up 1st time Kotlin inventory subgraph build

### DIFF
--- a/subgraphs/inventory/Dockerfile
+++ b/subgraphs/inventory/Dockerfile
@@ -2,16 +2,16 @@ from gradle:7.4.1-jdk11
 
 WORKDIR /usr/src/app
 
-COPY app/build.gradle.kts app/settings.gradle.kts /app/
+#COPY app/build.gradle app/settings.gradle .
 
 # Only download dependencies
 # Eat the expected build failure since no source code has been copied yet
-RUN gradle clean build --no-daemon > /dev/null 2>&1 || true
+#RUN gradle clean build --no-daemon --parallel > /dev/null 2>&1 || true
 
 # Copy all files
 COPY app .
 
 # Do the actual build
-RUN gradle clean build --no-daemon
+RUN gradle clean build --no-daemon --parallel
 
 CMD ["java", "-jar", "build/libs/app.jar"]

--- a/subgraphs/inventory/app/build.gradle
+++ b/subgraphs/inventory/app/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   id("org.springframework.boot") version "2.6.4"
   id("io.spring.dependency-management") version "1.0.11.RELEASE"


### PR DESCRIPTION
- switch from Kotlin Gradle scripts to regular Gradle saves ~20 seconds on 1st pass (90s vs. 68s)

Signed-off-by: Phil Prasek <prasek@gmail.com>