### PR TITLE
Remove support for legacy otel otlp/http port and add new default port

### DIFF
--- a/docker-compose.otel-collector.yml
+++ b/docker-compose.otel-collector.yml
@@ -7,6 +7,7 @@ services:
       - APOLLO_SCHEMA_CONFIG_EMBEDDED=true
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
     ports:
@@ -17,18 +18,21 @@ services:
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   inventory:
     container_name: inventory
     build: ./subgraphs/inventory
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   users:
     container_name: users
     build: ./subgraphs/users
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   pandas:
     container_name: pandas
     build: ./subgraphs/pandas
@@ -41,7 +45,7 @@ services:
     ports:
       - "9464:9464"
       - "4317:4317"
-      - "55681:55681"
+      - "4318:4318"
       - "55679:55679"
     depends_on:
       - zipkin

--- a/docker-compose.router-otel.yml
+++ b/docker-compose.router-otel.yml
@@ -14,18 +14,21 @@ services:
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   inventory:
     container_name: inventory
     build: ./subgraphs/inventory
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   users:
     container_name: users
     build: ./subgraphs/users
     environment:
       - APOLLO_OTEL_EXPORTER_TYPE=collector
       - APOLLO_OTEL_EXPORTER_HOST=collector
+      - APOLLO_OTEL_EXPORTER_PORT=4318
   pandas:
     container_name: pandas
     build: ./subgraphs/pandas
@@ -38,7 +41,7 @@ services:
     ports:
       - "9464:9464"
       - "4317:4317"
-      - "55681:55681"
+      - "4318:4318"
       - "55679:55679"
     depends_on:
       - zipkin


### PR DESCRIPTION
- for https://github.com/open-telemetry/opentelemetry-collector/pull/4916

Signed-off-by: Phil Prasek <prasek@gmail.com>