### PR TITLE
the router configuration format changed

### DIFF
--- a/router/configuration.yaml
+++ b/router/configuration.yaml
@@ -3,15 +3,7 @@ server:
   cors:
     origins:
       - https://studio.apollographql.com
-subgraphs:
-  users:
-    routing_url: http://users:4000/graphql
-  products:
-    routing_url: http://products:4000/graphql
-  inventory:
-    routing_url: http://inventory:4000/graphql
-plugins:
-  com.apollographql.reporting:
+telemetry:
     opentelemetry:
       otlp:
         tracing:


### PR DESCRIPTION
* we do not need to override the routing url if it is already present in
the schema
* the reporting plugin configuration is nox at the top level