### PR TITLE
Speed up the start up times for the Kotlin app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ dist
 
 # TernJS port file
 .tern-port
+

--- a/subgraphs/inventory/Dockerfile
+++ b/subgraphs/inventory/Dockerfile
@@ -24,4 +24,4 @@ WORKDIR /usr/src/app
 
 COPY --from=TEMP_BUILD_IMAGE /usr/src/app/build/libs/$ARTIFACT_NAME .
 
-ENTRYPOINT ["java", "-jar", "-noverify", $ARTIFACT_NAME]
+ENTRYPOINT exec "java" "-jar" "-noverify" "${ARTIFACT_NAME}"

--- a/subgraphs/inventory/Dockerfile
+++ b/subgraphs/inventory/Dockerfile
@@ -1,4 +1,5 @@
-from gradle:7.4.1-jdk11
+# Use a separate layer for the build for better caching
+FROM gradle:7.4.1-jdk11 AS TEMP_BUILD_IMAGE
 
 WORKDIR /usr/src/app
 
@@ -14,4 +15,13 @@ COPY app .
 # Do the actual build
 RUN gradle clean build --no-daemon --parallel
 
-CMD ["java", "-jar", "build/libs/app.jar"]
+
+# Create a new layer with the build output to run the app
+FROM openjdk:11-jre-slim
+ENV ARTIFACT_NAME=app.jar
+
+WORKDIR /usr/src/app
+
+COPY --from=TEMP_BUILD_IMAGE /usr/src/app/build/libs/$ARTIFACT_NAME .
+
+ENTRYPOINT ["java", "-jar", "-noverify", $ARTIFACT_NAME]

--- a/subgraphs/inventory/app/.gitignore
+++ b/subgraphs/inventory/app/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/subgraphs/inventory/app/src/main/resources/application.properties
+++ b/subgraphs/inventory/app/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 server.port=4000
+spring.main.lazy-initialization=true
+spring.jmx.enabled=false


### PR DESCRIPTION
The start up times for the Kotlin app can be helped out a little bit. This will still be slow for first time builds or code changes, but restarts and cached runs might see a small improvement

* Add another layer to the docker image for the build and JAR so that can be cached easier.
* Use a smaller docker image for the running of the JAR
* Add some Spring properties to reduce the auto-configuration times