### PR TITLE
Use latest rover RC

### DIFF
--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -20,7 +20,6 @@ jobs:
           echo rover - installing ...
           echo ---------------------------------------------------------------
           curl -sSL https://rover.apollo.dev/nix/latest | sh
-          curl -sSL https://rover.apollo.dev/plugins/rover-fed2/nix/latest | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -19,7 +19,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -62,5 +62,6 @@ jobs:
           docker-compose -f docker-compose.router.yml logs
       - name: smoke test
         run: .scripts/smoke.sh 4000
+        continue-on-error: true
       - name: docker-compose down
         run: docker-compose -f docker-compose.router.yml down

--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -62,6 +62,5 @@ jobs:
           docker-compose -f docker-compose.router.yml logs
       - name: smoke test
         run: .scripts/smoke.sh 4000
-        continue-on-error: true
       - name: docker-compose down
         run: docker-compose -f docker-compose.router.yml down

--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -19,7 +19,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main-router.yml
+++ b/.github/workflows/main-router.yml
@@ -19,7 +19,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          curl -sSL https://rover.apollo.dev/nix/0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
           echo rover - installing ...
           echo ---------------------------------------------------------------
           curl -sSL https://rover.apollo.dev/nix/latest | sh
-          curl -sSL https://rover.apollo.dev/plugins/rover-fed2/nix/latest | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed-router.yml
+++ b/.github/workflows/managed-router.yml
@@ -23,7 +23,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          curl -sSL https://rover.apollo.dev/nix/0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed-router.yml
+++ b/.github/workflows/managed-router.yml
@@ -23,7 +23,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed-router.yml
+++ b/.github/workflows/managed-router.yml
@@ -23,7 +23,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed-router.yml
+++ b/.github/workflows/managed-router.yml
@@ -24,7 +24,6 @@ jobs:
           echo rover - installing ...
           echo ---------------------------------------------------------------
           curl -sSL https://rover.apollo.dev/nix/latest | sh
-          curl -sSL https://rover.apollo.dev/plugins/rover-fed2/nix/latest | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -27,8 +27,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/v0.4.8| sh
-          curl -sSL https://rover.apollo.dev/plugins/rover-fed2/nix/v0.4.8 | sh -s -- --elv2-license accept
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -27,7 +27,7 @@ jobs:
           echo ---------------------------------------------------------------
           echo rover - installing ...
           echo ---------------------------------------------------------------
-          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh -s -- --elv2-license accept
           echo "$HOME/.rover/bin" >> ${GITHUB_PATH}
       -
         name: update docker-compose

--- a/.scripts/compose.sh
+++ b/.scripts/compose.sh
@@ -3,5 +3,5 @@
 set -e
 
 echo -------------------------------------------------------------------------------------------
-( set -x; ${ROVER_BIN:-'rover'} fed2 supergraph compose --config ./supergraph.yaml > ./supergraph.graphql)
+( set -x; ${ROVER_BIN:-'rover'} supergraph compose --config ./supergraph.yaml > ./supergraph.graphql)
 echo -------------------------------------------------------------------------------------------

--- a/.scripts/config.sh
+++ b/.scripts/config.sh
@@ -2,6 +2,7 @@
 
 source "$(dirname $0)/subgraphs.sh"
 
+echo "federation_version: 2"
 echo "subgraphs:"
 for subgraph in ${subgraphs[@]}; do
   url="url_$subgraph"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You'll need:
 To install `rover`:
 
 ```sh
-curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
 ```
 
 For help with `rover` see [installing the Rover CLI](https://www.apollographql.com/docs/federation/v2/quickstart/#1-install-the-rover-cli).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You'll need:
 To install `rover`:
 
 ```sh
-curl -sSL https://rover.apollo.dev/nix/v0.4.8 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.0 | sh
 ```
 
 For help with `rover` see [installing the Rover CLI](https://www.apollographql.com/docs/federation/v2/quickstart/#1-install-the-rover-cli).
@@ -260,16 +260,6 @@ That's it!
 
 This section assumes you have `docker`, `docker-compose` and the `rover` core binary installed from the [Prerequisites](#prerequisites) sections above.
 
-### Additional Prerequisites
-
-#### Install the Federation 2 plugin for `rover` for local composition
-
-```
-curl https://rover.apollo.dev/plugins/rover-fed2/nix/v0.4.8 | sh
-```
-
-For help with `rover` see [installing the Rover CLI](https://www.apollographql.com/docs/federation/v2/quickstart/#1-install-the-rover-cli).
-
 ### Local Supergraph Composition
 
 See also: [Apollo Federation docs](https://www.apollographql.com/docs/federation/v2/quickstart/)
@@ -290,7 +280,7 @@ make supergraph
 which runs:
 
 ```
-rover fed2 supergraph compose --config ./supergraph.yaml > supergraph.graphql
+rover supergraph compose --config ./supergraph.yaml > supergraph.graphql
 ```
 
 and then runs:
@@ -471,7 +461,7 @@ service:
 
 As a Graph Router, the Apollo Router plays the same role as the Apollo Gateway. The same subgraph schemas and composed supergraph schema can be used in both the Router and the Gateway.
 
-This demo shows using the Apollo Router with a Federation 2 supergraph schema, composed using the Fed 2 `rover fed2 supergraph compose` command. To see the Router working with Federation 1 composition, checkout the Apollo Router section of [apollographql/supergraph-demo](https://github.com/apollographql/supergraph-demo/blob/main/README.md#apollo-router).
+This demo shows using the Apollo Router with a Federation 2 supergraph schema, composed using the Fed 2 `rover supergraph compose` command. To see the Router working with Federation 1 composition, checkout the Apollo Router section of [apollographql/supergraph-demo](https://github.com/apollographql/supergraph-demo/blob/main/README.md#apollo-router).
 
 [Early benchmarks](https://www.apollographql.com/blog/announcement/backend/apollo-router-our-graphql-federation-runtime-in-rust) show that the Router adds less than 10ms of latency to each operation, and it can process 8x the load of the JavaScript Apollo Gateway.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- `./examples` - various examples of subgraphs with supergraph.yaml config that can be used with the `rover fed2` subcommand installed. See the main [README.md](../README.md#prerequisites) for rover install instructions.
+- `./examples` - various examples of subgraphs with supergraph.yaml config that can be used with the `rover supergraph` subcommand. See the main [README.md](../README.md#prerequisites) for rover install instructions.
 
 ## Using the `rover` CLI with the examples
 
@@ -10,13 +10,13 @@ Run an example:
 ```
 cd ./basic
 
-rover fed2 supergraph compose --config ./supergraph.yaml
+rover supergraph compose --config ./supergraph.yaml
 ```
 
 Verify it composes successfully:
 
 ```
-rover fed2 supergraph compose --config ./supergraph.yaml
+rover supergraph compose --config ./supergraph.yaml
 WARN: [InconsistentFieldType]: Field "A.v1" has mismatched, but compatible, types across subgraphs: will use type "Int" (from subgraph "a") in supergraph but "A.v1" has subtype "Int!" in subgraph "b"
 
 CoreSchema:

--- a/examples/basic/supergraph.yaml
+++ b/examples/basic/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/complex_key/supergraph.yaml
+++ b/examples/complex_key/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/cost_handling/supergraph.yaml
+++ b/examples/cost_handling/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/efficient_parallels/supergraph.yaml
+++ b/examples/efficient_parallels/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/entity_in_list/supergraph.yaml
+++ b/examples/entity_in_list/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/interface_simple/supergraph.yaml
+++ b/examples/interface_simple/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/products/supergraph.yaml
+++ b/examples/products/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/provides/supergraph.yaml
+++ b/examples/provides/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/examples/requires/supergraph.yaml
+++ b/examples/requires/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   a:
     routing_url: http://a:4000/graphql

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -1,15 +1,13 @@
 
 schema
-  @core(feature: "https://specs.apollo.dev/core/v0.2")
-  @core(feature: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
-  @core(feature: "https://specs.apollo.dev/tag/v0.1")
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.2")
 {
   query: Query
 }
 
-directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -17,19 +15,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) repeatable 
 
 directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-enum core__Purpose {
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
-  SECURITY
-
-  """
-  `EXECUTION` features provide metadata necessary for operation execution.
-  """
-  EXECUTION
-}
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 type DeliveryEstimates
   @join__type(graph: INVENTORY)
@@ -45,6 +33,20 @@ enum join__Graph {
   PANDAS @join__graph(name: "pandas", url: "http://pandas:4000/graphql")
   PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
   USERS @join__graph(name: "users", url: "http://users:4000/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
 }
 
 type Panda

--- a/supergraph.yaml
+++ b/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 2
 subgraphs:
   inventory:
     routing_url: http://inventory:4000/graphql


### PR DESCRIPTION
- Updated generated supergraph to include new `@link` specs
- Updated instructions to point to `rover@0.5.0-rc.1`
- Added the required `federation_version: 2` to config YAMLs

Additionally, I removed the `CI Router` as a required status check https://github.com/apollographql/supergraph-demo-fed2/settings/branch_protection_rules/22897270 since router doesn't yet support `@link`.