### PR TITLE
`@deprecated` example

### DIFF
--- a/subgraphs/products/products.graphql
+++ b/subgraphs/products/products.graphql
@@ -15,6 +15,7 @@ interface ProductItf implements SkuItf {
   dimensions: ProductDimension
   createdBy: User
   hidden: String @inaccessible
+  oldField: String @deprecated(reason: "refactored out")
 }
 
 interface SkuItf {
@@ -30,6 +31,7 @@ type Product implements ProductItf & SkuItf @key(fields: "id") @key(fields: "sku
   createdBy: User
   hidden: String
   reviewsScore: Float!
+  oldField: String
 }
 enum ShippingClass {
   STANDARD

--- a/subgraphs/products/products.js
+++ b/subgraphs/products/products.js
@@ -20,14 +20,15 @@ const { readFileSync } = require('fs');
 const port = process.env.APOLLO_PORT || 4000;
 
 const products = [
-    { id: 'apollo-federation', sku: 'federation', package: '@apollo/federation'},
-    { id: 'apollo-studio', sku: 'studio', package: ''},
+    { id: 'apollo-federation', sku: 'federation', package: '@apollo/federation', oldField: 'deprecated'},
+    { id: 'apollo-studio', sku: 'studio', package: '', oldField: 'deprecated'},
 ]
 
 const variationByProduct = [
     { id: 'apollo-federation', variation: { id: "OSS", name: "platform"}},
     { id: 'apollo-studio', variation: { id: "platform", name: "platform-name"}},
 ]
+
 const typeDefs = gql(readFileSync('./products.graphql', { encoding: 'utf-8' }));
 const resolvers = {
     Query: {
@@ -51,7 +52,7 @@ const resolvers = {
                 r(variation);
 	      }
 	      r({ id: 'defaultVariation', name: 'default variation' });
-	    }, 5000));
+	    }, 1000));
         },
         dimensions: () => {
             return { size: "1", weight: 1 }

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -80,6 +80,7 @@ type Product implements ProductItf & SkuItf
   createdBy: User @join__field(graph: PRODUCTS)
   hidden: String @join__field(graph: PRODUCTS)
   reviewsScore: Float! @join__field(graph: REVIEWS, override: "products")
+  oldField: String @join__field(graph: PRODUCTS)
   reviewsCount: Int! @join__field(graph: REVIEWS)
   reviews: [Review!]! @join__field(graph: REVIEWS)
 }
@@ -106,6 +107,7 @@ interface ProductItf implements SkuItf
   variation: ProductVariation @join__field(graph: PRODUCTS)
   createdBy: User @join__field(graph: PRODUCTS)
   hidden: String @inaccessible @join__field(graph: PRODUCTS)
+  oldField: String @deprecated(reason: "refactored out") @join__field(graph: PRODUCTS)
   reviewsCount: Int! @join__field(graph: REVIEWS)
   reviewsScore: Float! @join__field(graph: REVIEWS)
   reviews: [Review!]! @join__field(graph: REVIEWS)


### PR DESCRIPTION
To verify you can fetch `@deprecated` fields from gateway and router, and that they're returned in the introspection results:
```
#gateway
make demo-local

#router
make demo-local-router
```

then if you leave the router and subgraphs running:
```
make docker-up-local-router
```

and with http://localhost:4000

<img width="1723" alt="image" src="https://user-images.githubusercontent.com/284840/185271916-726ce6cf-9f48-4c23-9673-442b972ec084.png">

which is the same as test 7 in `.scripts/smoke.sh`

then to cleanup:
```
make docker-down-router
```

Signed-off-by: Phil Prasek <prasek@gmail.com>
