### PR TITLE
Add protobuf install for native router plugin dockerfile

### DIFF
--- a/supergraph/router-rust-plugin/Dockerfile
+++ b/supergraph/router-rust-plugin/Dockerfile
@@ -12,7 +12,7 @@ RUN rustup component add rustfmt
 # copy over your manifests
 COPY ./Cargo.toml ./Cargo.toml
 
-# add protobul dep
+# add protobuf dep
 RUN apt-get update && apt-get install -y protobuf-compiler
 
 # this build step will cache your dependencies

--- a/supergraph/router-rust-plugin/Dockerfile
+++ b/supergraph/router-rust-plugin/Dockerfile
@@ -12,6 +12,9 @@ RUN rustup component add rustfmt
 # copy over your manifests
 COPY ./Cargo.toml ./Cargo.toml
 
+# add protoful dep
+RUN apt-get update && apt-get install -y protobuf-compiler
+
 # this build step will cache your dependencies
 RUN cargo build --release
 RUN rm src/*.rs

--- a/supergraph/router-rust-plugin/Dockerfile
+++ b/supergraph/router-rust-plugin/Dockerfile
@@ -12,7 +12,7 @@ RUN rustup component add rustfmt
 # copy over your manifests
 COPY ./Cargo.toml ./Cargo.toml
 
-# add protoful dep
+# add protobul dep
 RUN apt-get update && apt-get install -y protobuf-compiler
 
 # this build step will cache your dependencies


### PR DESCRIPTION
Running this dockerfile locally no longer works due to requiring protobuf to be installed as brought up in the apollo router changelog [here](https://github.com/apollographql/router/releases/tag/v1.6.0).

This PR should fix [pipeline](https://github.com/apollographql/supergraph-demo-fed2/actions/runs/3681364234/jobs/6227969920).