### PR TITLE
jwt auth with `run-router-local-entitled`

### DIFF
--- a/.github/workflows/local-router-no-code.yaml
+++ b/.github/workflows/local-router-no-code.yaml
@@ -78,7 +78,7 @@ jobs:
           docker-compose \
            -f docker-compose.yaml \
            -f opentelemetry/docker-compose.otel.yaml \
-           -f examples/local/docker-compose.router-no-code.yaml \
+           -f misc/local/docker-compose.router-no-code.yaml \
            logs
       - name: docker-compose down
         run: docker-compose down --remove-orphans

--- a/.scripts/graph-api-env-export.sh
+++ b/.scripts/graph-api-env-export.sh
@@ -12,4 +12,5 @@ export APOLLO_KEY=$APOLLO_KEY
 export APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF
 
 #echo "key:$APOLLO_KEY"
-#echo "ref:$APOLLO_GRAPH_REF"
+#.echo "ref:$APOLLO_GRAPH_REF"
+#export APOLLO_UPLINK_ENDPOINTS="https://aws.uplink.api.apollographql.com/, https://uplink.api.apollographql.com/"

--- a/.scripts/graph-api-env-export.sh
+++ b/.scripts/graph-api-env-export.sh
@@ -10,3 +10,6 @@ fi
 
 export APOLLO_KEY=$APOLLO_KEY
 export APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF
+
+#echo "key:$APOLLO_KEY"
+#echo "ref:$APOLLO_GRAPH_REF"

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ run-supergraph-local-entitled: up-subgraphs config compose run-router-local-enti
 
 .PHONY: run-router-local-entitled
 run-router-local-entitled:
-	@source "./.scripts/graph-api-env-export.sh" && set -x; \
+	@source "./.scripts/graph-api-env.sh" && set -x; \
 	 ./router --version && \
 	 ./router --dev \
 	  -c ./supergraph/router.yaml \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ run-router:
 	 ./router --version && \
 	 ./router --dev \
 	  -c ./supergraph/router.yaml \
-	  --log info
+	  --log "info,apollo_router::uplink=debug"
 
 .PHONY: query
 query:

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,20 @@ run-router-local:
 	  -s ./supergraph/schema/local.graphql \
 	  --log info
 
+# standalone router with local composition and uplink entitlement
+
+.PHONY: run-supergraph-local-entitled
+run-supergraph-local-entitled: up-subgraphs config compose run-router-local-entitled
+
+.PHONY: run-router-local-entitled
+run-router-local-entitled:
+	@source "./.scripts/graph-api-env-export.sh" && set -x; \
+	 ./router --version && \
+	 ./router --dev \
+	  -c ./supergraph/router.yaml \
+	  -s ./supergraph/schema/local.graphql \
+	  --log "info,apollo_router::uplink=debug"
+
 # standalone router with local composition and no --dev flag
 
 .PHONY: run-supergraph-local-no-dev

--- a/subgraphs/products/products.graphql
+++ b/subgraphs/products/products.graphql
@@ -1,5 +1,5 @@
 extend schema
-    @link(url: "https://specs.apollo.dev/federation/v2.1",
+    @link(url: "https://specs.apollo.dev/federation/v2.3",
        import: ["@key", "@shareable", "@tag", "@inaccessible", "@composeDirective"])
     @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
     @composeDirective(name: "@myDirective")
@@ -30,7 +30,13 @@ interface SkuItf {
   sku: String
 }
 
-type Product implements ProductItf & SkuItf @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }"){
+interface Prod @key(fields: "id"){
+  id: ID!
+  sku: String
+  name: String
+}
+
+type Product implements Prod & ProductItf & SkuItf @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }"){
   id: ID! @tag(name: "hi-from-products")
   sku: String
   name: String @hello

--- a/supergraph/router.yaml
+++ b/supergraph/router.yaml
@@ -20,6 +20,15 @@ telemetry:
       protocol: grpc
       batch_processor:
         max_export_timeout: 42s
+authentication:
+ jwt:
+   jwks: # This key is required.
+     - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
+       issuer: auth0
+
+   # These keys are optional. Default values are shown.
+   header_name: Authorization
+   header_value_prefix: Bearer
 
 # --------------------
 # note: `router --dev` has these default settings and enables the --hot-reload flag

--- a/supergraph/schema/docker.graphql
+++ b/supergraph/schema/docker.graphql
@@ -1,7 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/tag/v0.2")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.3")
   @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
   @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", {name: "@anotherDirective", as: "@hello"}])
 {
@@ -12,19 +12,23 @@ directive @hello on FIELD_DEFINITION
 
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
 directive @myDirective(a: String!) on FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
 type DeliveryEstimates
   @join__type(graph: INVENTORY)
@@ -64,8 +68,17 @@ type Panda
   favoriteFood: String @tag(name: "nom-nom-nom")
 }
 
-type Product implements ProductItf & SkuItf
+interface Prod
+  @join__type(graph: PRODUCTS, key: "id")
+{
+  id: ID!
+  sku: String
+  name: String
+}
+
+type Product implements ProductItf & Prod & SkuItf
   @join__implements(graph: INVENTORY, interface: "ProductItf")
+  @join__implements(graph: PRODUCTS, interface: "Prod")
   @join__implements(graph: PRODUCTS, interface: "ProductItf")
   @join__implements(graph: PRODUCTS, interface: "SkuItf")
   @join__implements(graph: REVIEWS, interface: "ProductItf")
@@ -151,9 +164,9 @@ enum ShippingClass
   @join__type(graph: INVENTORY)
   @join__type(graph: PRODUCTS)
 {
-  STANDARD
-  EXPRESS
-  OVERNIGHT
+  STANDARD @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+  EXPRESS @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+  OVERNIGHT @join__enumValue(graph: INVENTORY)
 }
 
 interface SkuItf

--- a/supergraph/schema/local.graphql
+++ b/supergraph/schema/local.graphql
@@ -1,7 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/tag/v0.2")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.3")
   @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
   @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", {name: "@anotherDirective", as: "@hello"}])
 {
@@ -12,19 +12,23 @@ directive @hello on FIELD_DEFINITION
 
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
 directive @myDirective(a: String!) on FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
 type DeliveryEstimates
   @join__type(graph: INVENTORY)
@@ -64,8 +68,17 @@ type Panda
   favoriteFood: String @tag(name: "nom-nom-nom")
 }
 
-type Product implements ProductItf & SkuItf
+interface Prod
+  @join__type(graph: PRODUCTS, key: "id")
+{
+  id: ID!
+  sku: String
+  name: String
+}
+
+type Product implements ProductItf & Prod & SkuItf
   @join__implements(graph: INVENTORY, interface: "ProductItf")
+  @join__implements(graph: PRODUCTS, interface: "Prod")
   @join__implements(graph: PRODUCTS, interface: "ProductItf")
   @join__implements(graph: PRODUCTS, interface: "SkuItf")
   @join__implements(graph: REVIEWS, interface: "ProductItf")
@@ -151,9 +164,9 @@ enum ShippingClass
   @join__type(graph: INVENTORY)
   @join__type(graph: PRODUCTS)
 {
-  STANDARD
-  EXPRESS
-  OVERNIGHT
+  STANDARD @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+  EXPRESS @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+  OVERNIGHT @join__enumValue(graph: INVENTORY)
 }
 
 interface SkuItf


### PR DESCRIPTION
- Adds `make run-router-local-entitled`
- for use with an `Observer` API key role or higher
- authenticates local router with GraphOS to get Enterprise plan entitlement using `APOLLO_KEY` and `APOLLO_GRAPH_REF`
- runs local supergraph schema