### PR TITLE
Update expected error message from router

### DIFF
--- a/.scripts/smoke.sh
+++ b/.scripts/smoke.sh
@@ -155,7 +155,7 @@ EOF
 OP_3=contains
 
 read -r -d '' EXP_3 <<"EOF"
-Cannot query field \"hidden\" on type \"ProductItf\".
+no field `hidden` in type `ProductItf`
 EOF
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
The router manipulates the query before it is validated in graphql-js, and if the operation is querying a field that doesn't exist, the router returns an error early. That error has a different format than graphql-js. This change should fix the smoke test.